### PR TITLE
Make lune shrooms able to spread up and down

### DIFF
--- a/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
+++ b/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
@@ -33,16 +33,12 @@ public class LuneShroomBlock extends Block {
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
         int count = 1;
         for(int i = 0; i < 7; i++){
-            for(int j = 0; j < 7; j++){
-                BlockPos checkPos = new BlockPos(pos.getX() - 3 + i, pos.getY(), pos.getZ() - 3 + j);
-                if (world.getBlockState(checkPos).isOf(ModBlocks.LUNE_SHROOM_BLOCK)){
-                    count++;
-                }
-                if (world.getBlockState(checkPos.up()).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
-                    count++;
-                }
-                if (world.getBlockState(checkPos.down()).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
-                    count++;
+            for(int j = 0; j < 3; j++){
+                for(int k = 0; k<7; k++) {
+                    BlockPos checkPos = new BlockPos(pos.getX() - 3 + i, pos.getY() - 1 + j, pos.getZ() - 3 + k);
+                    if (world.getBlockState(checkPos).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
+                        count++;
+                    }
                 }
             }
         }

--- a/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
+++ b/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
@@ -34,7 +34,7 @@ public class LuneShroomBlock extends Block {
         int count = 1;
         for(int i = 0; i < 7; i++){
             for(int j = 0; j < 3; j++){
-                for(int k = 0; k<7; k++) {
+                for(int k = 0; k < 7; k++){
                     BlockPos checkPos = new BlockPos(pos.getX() - 3 + i, pos.getY() - 1 + j, pos.getZ() - 3 + k);
                     if (world.getBlockState(checkPos).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
                         count++;

--- a/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
+++ b/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
@@ -31,7 +31,7 @@ public class LuneShroomBlock extends Block {
 
     @Override
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        int count = 0;
+        int count = 1;
         for(int i = 0; i < 7; i++){
             for(int j = 0; j < 7; j++){
                 BlockPos checkPos = new BlockPos(pos.getX() - 3 + i, pos.getY(), pos.getZ() - 3 + j);

--- a/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
+++ b/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
@@ -31,11 +31,17 @@ public class LuneShroomBlock extends Block {
 
     @Override
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        int count = 1;
+        int count = 0;
         for(int i = 0; i < 7; i++){
             for(int j = 0; j < 7; j++){
                 BlockPos checkPos = new BlockPos(pos.getX() - 3 + i, pos.getY(), pos.getZ() - 3 + j);
                 if (world.getBlockState(checkPos).isOf(ModBlocks.LUNE_SHROOM_BLOCK)){
+                    count++;
+                }
+                if (world.getBlockState(checkPos.up()).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
+                    count++;
+                }
+                if (world.getBlockState(checkPos.down()).isOf(ModBlocks.LUNE_SHROOM_BLOCK)) {
                     count++;
                 }
             }
@@ -44,6 +50,12 @@ public class LuneShroomBlock extends Block {
             BlockPos blockPos = new BlockPos(pos.getX() - 3 + (int)(random.nextFloat()*7), pos.getY(), pos.getZ() - 3 + (int)(random.nextFloat()*7));
             if (canPlaceAt(this.getDefaultState(), world, blockPos)) {
                 world.setBlockState(blockPos, this.getDefaultState());
+            }
+            else if(canPlaceAt(this.getDefaultState(), world, blockPos.up())) {
+                world.setBlockState(blockPos.up(), this.getDefaultState());
+            }
+            else if(canPlaceAt(this.getDefaultState(), world, blockPos.down())) {
+                world.setBlockState(blockPos.down(), this.getDefaultState());
             }
         }
     }

--- a/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
+++ b/src/main/java/com/github/ethanicuss/astraladditions/blocks/LuneShroomBlock.java
@@ -47,7 +47,8 @@ public class LuneShroomBlock extends Block {
             if (canPlaceAt(this.getDefaultState(), world, blockPos)) {
                 world.setBlockState(blockPos, this.getDefaultState());
             }
-            else if(canPlaceAt(this.getDefaultState(), world, blockPos.up())) {
+            // Prioritizes spreading up over down when both are available. Uncomment the random check below to change to random chance
+            else if(/*random.nextFloat() >= 0.5 &&*/ canPlaceAt(this.getDefaultState(), world, blockPos.up())) {
                 world.setBlockState(blockPos.up(), this.getDefaultState());
             }
             else if(canPlaceAt(this.getDefaultState(), world, blockPos.down())) {


### PR DESCRIPTION
Expanded the area where lune shrooms scan for other lune shrooms by 1 block up and down.
They will now be able to spread to anywhere in that area. 
Spreading up is chosen over spreading down when both are possible at the same XZ coords, since I think it makes sense for this kind of arrangement: (if you disagree, feel free to change it to random chance - it's included too, just uncomment the first part of the _if_ condition)
![SpreadUp](https://github.com/user-attachments/assets/d2fdbd2a-5c07-4e2c-893e-e1c57ed723de)
